### PR TITLE
assign undefined to current path if does not exist

### DIFF
--- a/dist/gop.js
+++ b/dist/gop.js
@@ -1,17 +1,20 @@
 "use strict";
 exports.__esModule = true;
 exports.getObjectProperty = function (obj, path, defaultValue) {
-    var newObj = {};
-    var defaultReturn = typeof defaultValue !== 'undefined' ? defaultValue : undefined;
-    if (!obj || typeof obj !== 'object' || typeof path !== 'string') {
+    var defaultReturn = typeof defaultValue !== "undefined" ? defaultValue : undefined;
+    if (!obj || typeof obj !== "object" || typeof path !== "string") {
         return defaultReturn;
     }
-    var paths = path.split('.');
-    var property = paths[0];
+    var paths = path.split(".");
+    var currentProperty = paths[0];
     if (paths.length === 1) {
-        return obj.hasOwnProperty(property) ? obj[property] : defaultReturn;
+        return obj.hasOwnProperty(currentProperty)
+            ? obj[currentProperty]
+            : defaultReturn;
     }
     paths.shift();
-    newObj = obj.hasOwnProperty(property) ? obj[property] : {};
-    return exports.getObjectProperty(newObj, paths.join('.'), defaultReturn);
+    var newObj = obj.hasOwnProperty(currentProperty)
+        ? obj[currentProperty]
+        : undefined;
+    return exports.getObjectProperty(newObj, paths.join("."), defaultReturn);
 };

--- a/src/gop.ts
+++ b/src/gop.ts
@@ -3,7 +3,6 @@ export const getObjectProperty = (
   path: string,
   defaultValue?: any,
 ): any => {
-  let newObj = {};
   const defaultReturn =
     typeof defaultValue !== "undefined" ? defaultValue : undefined;
 
@@ -12,13 +11,17 @@ export const getObjectProperty = (
   }
 
   const paths = path.split(".");
-  const [property] = paths;
+  const [currentProperty] = paths;
 
   if (paths.length === 1) {
-    return obj.hasOwnProperty(property) ? obj[property] : defaultReturn;
+    return obj.hasOwnProperty(currentProperty)
+      ? obj[currentProperty]
+      : defaultReturn;
   }
 
   paths.shift();
-  newObj = obj.hasOwnProperty(property) ? obj[property] : {};
+  const newObj = obj.hasOwnProperty(currentProperty)
+    ? obj[currentProperty]
+    : undefined;
   return getObjectProperty(newObj, paths.join("."), defaultReturn);
 };


### PR DESCRIPTION
Prevents unnecessary evaluation of every path member when a previous path was undefined.

Fixes #7.